### PR TITLE
Refactor of ConnectionRepository calls and usages in the project.

### DIFF
--- a/backend/server/application/abandon.go
+++ b/backend/server/application/abandon.go
@@ -1,9 +1,5 @@
 package application
 
-import (
-	"chess/server/shared/wsrouter"
-)
-
 type AbandonOutput struct {
 	Action string `json:"action"`
 }
@@ -15,10 +11,10 @@ func NewAbandonAction() *AbandonAction {
 	return &AbandonAction{}
 }
 
-func (uc *AbandonAction) Invoke(ctx *wsrouter.Context) error {
-	output := AbandonOutput{
+func (uc *AbandonAction) Invoke() *AbandonOutput {
+	output := &AbandonOutput{
 		Action: "abandon",
 	}
 
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return output
 }

--- a/backend/server/application/create_room.go
+++ b/backend/server/application/create_room.go
@@ -51,7 +51,7 @@ func (uc *CreateRoomAction) Invoke(p *CreateRoomParams) (*domain.Room, error) {
 		return nil, err
 	}
 
-	player := domain.NewPlayer(uc.c.GetWebSocketConnection(), p.PlayerID)
+	player := domain.NewPlayer(uc.c, p.PlayerID)
 
 	r := domain.NewRoom(p.RoomID)
 	err := r.AddPlayer(player)

--- a/backend/server/application/get_rooms.go
+++ b/backend/server/application/get_rooms.go
@@ -57,37 +57,9 @@ func NewGetRoomsAction(rm *domain.RoomManager) *GetRoomsAction {
 }
 
 func (uc *GetRoomsAction) Invoke() *GetRoomsOutput {
-	uc.addTestRooms(uc.rm)
 	rooms := uc.rm.GetRooms()
 	output := newGetRoomsOutput(rooms)
 	log.Println("==> Get rooms output: ", shared.ToJSONString(output))
 
 	return output
-}
-
-func (uc *GetRoomsAction) addTestRooms(rm *domain.RoomManager) {
-	roomTest1 := &domain.Room{
-		ID: "roomTest1",
-		Player1: &domain.Player{
-			Ws: nil,
-			ID: "player1",
-		},
-		Player2: &domain.Player{
-			Ws: nil,
-			ID: "player2",
-		},
-	}
-	roomTest2 := &domain.Room{
-		ID: "roomTest2",
-		Player1: &domain.Player{
-			Ws: nil,
-			ID: "player3",
-		},
-		Player2: &domain.Player{
-			Ws: nil,
-			ID: "player4",
-		},
-	}
-	rm.AddRoom(roomTest1)
-	rm.AddRoom(roomTest2)
 }

--- a/backend/server/application/get_timers.go
+++ b/backend/server/application/get_timers.go
@@ -17,15 +17,15 @@ func NewGetTimersAction() *GetTimersAction {
 	return &GetTimersAction{}
 }
 
-func (uc *GetTimersAction) Invoke(ctx *wsrouter.Context) error {
+func (uc *GetTimersAction) Invoke(ctx *wsrouter.Context) *GetTimersOutput {
 	t1 := ctx.Player.TimeLeft()
 	t2 := ctx.Enemy.TimeLeft()
 
-	output := GetTimersOutput{
+	output := &GetTimersOutput{
 		Action:     "get-timers",
 		PlayerTime: t1,
 		EnemyTime:  t2,
 	}
 
-	return ctx.OwnRepository.SendWebSocketMessage(output)
+	return output
 }

--- a/backend/server/application/join_room.go
+++ b/backend/server/application/join_room.go
@@ -71,7 +71,7 @@ func (uc *JoinRoomAction) Invoke(p *JoinRoomParams) (*domain.Room, error) {
 		return nil, err
 	}
 
-	player := domain.NewPlayer(uc.c.GetWebSocketConnection(), p.PlayerID)
+	player := domain.NewPlayer(uc.c, p.PlayerID)
 	err := room.AddPlayer(player)
 	if err != nil {
 		return nil, err

--- a/backend/server/application/request_draw.go
+++ b/backend/server/application/request_draw.go
@@ -13,10 +13,10 @@ func NewRequestDrawAction() *RequestDrawAction {
 	return &RequestDrawAction{}
 }
 
-func (uc *RequestDrawAction) Invoke(ctx *wsrouter.Context) error {
-	output := RequestDrawOutput{
+func (uc *RequestDrawAction) Invoke(ctx *wsrouter.Context) *RequestDrawOutput {
+	output := &RequestDrawOutput{
 		Action: "draw-request",
 	}
 
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return output
 }

--- a/backend/server/application/response_draw.go
+++ b/backend/server/application/response_draw.go
@@ -20,11 +20,11 @@ func NewResponseDrawAction() *ResponseDrawAction {
 	return &ResponseDrawAction{}
 }
 
-func (uc *ResponseDrawAction) Invoke(ctx *wsrouter.Context, p *ResponseDrawParam) error {
-	output := ResponseDrawOutput{
+func (uc *ResponseDrawAction) Invoke(ctx *wsrouter.Context, p *ResponseDrawParam) *ResponseDrawOutput {
+	output := &ResponseDrawOutput{
 		Action:       "draw-response",
 		DrawResponse: p.DrawResponse,
 	}
 
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return output
 }

--- a/backend/server/application/start_game.go
+++ b/backend/server/application/start_game.go
@@ -20,7 +20,7 @@ func newStartGameOutput(playerColor domain.Color, opponentName string, durationM
 	}
 }
 
-func StartGameAction(p1, p2 *domain.Player, c1, c2 domain.ConnectionRepository, durationMs int) error {
+func StartGameAction(p1, p2 *domain.Player, durationMs int) (op1, op2 *StartGameOutput) {
 	p1.Color = domain.GetRandomColor()
 	if p1.Color == domain.WHITE {
 		p2.Color = domain.BLACK
@@ -30,12 +30,8 @@ func StartGameAction(p1, p2 *domain.Player, c1, c2 domain.ConnectionRepository, 
 		defer p2.StartTimer()
 	}
 
-	output := newStartGameOutput(p1.Color, p2.ID, durationMs)
-	err := c1.SendWebSocketMessage(output)
-	if err != nil {
-		return err
-	}
+	outputPlayer1 := newStartGameOutput(p1.Color, p2.ID, durationMs)
+	outputPlayer2 := newStartGameOutput(p2.Color, p1.ID, durationMs)
 
-	output = newStartGameOutput(p2.Color, p1.ID, durationMs)
-	return c2.SendWebSocketMessage(output)
+	return outputPlayer1, outputPlayer2
 }

--- a/backend/server/domain/check.go
+++ b/backend/server/domain/check.go
@@ -19,7 +19,6 @@ func (b *Board) positionIsUnderAttackUsingDirections(pos *Position, pieceType Pi
 		directions = []Direction{{-directions[0].x, -1}, {-directions[0].x, 1}}
 	}
 	for _, d := range directions {
-		// fmt.Println("pos: ", pos, "check ", pieceType.String(), " dir: ", d)
 		dCum := &Direction{0, 0}
 		for {
 			dCum.x += d.x

--- a/backend/server/domain/connection_repository.go
+++ b/backend/server/domain/connection_repository.go
@@ -1,8 +1,6 @@
 package domain
 
-import "chess/server/shared"
-
 type ConnectionRepository interface {
 	SendWebSocketMessage(interface{}) error
-	GetWebSocketConnection() *shared.WsConn
+	ReadMessage() ([]byte, error)
 }

--- a/backend/server/domain/move.go
+++ b/backend/server/domain/move.go
@@ -39,10 +39,8 @@ func (g *Game) Move(m *Move, promoteTo *PieceType) {
 
 	switch p.GetPieceType() {
 	case PAWN:
-		// fmt.Println("pawn move", m.From, m.To)
 		g.checkPawnMove(m, p.(*Pawn), promoteTo)
 	case KING:
-		// fmt.Println("king move", m.From, m.To)
 		g.checkCastleMove(m, p.(*King))
 		if g.ColorToMove == WHITE {
 			g.Board.whiteKingPos = m.To

--- a/backend/server/domain/player.go
+++ b/backend/server/domain/player.go
@@ -1,12 +1,12 @@
 package domain
 
 import (
-	"chess/server/shared"
 	"time"
 )
 
 type Player struct {
-	Ws             *shared.WsConn
+	ConnectionRepository
+
 	ID             string
 	Color          Color
 	TimeConsumedMS int
@@ -14,14 +14,14 @@ type Player struct {
 	paused         bool
 }
 
-func NewPlayer(ws *shared.WsConn, id string) *Player {
+func NewPlayer(repository ConnectionRepository, id string) *Player {
 	return &Player{
-		Ws:             ws,
-		ID:             id,
-		Color:          false,
-		TimeConsumedMS: 0,
-		LastClockTime:  time.Time{},
-		paused:         true,
+		ConnectionRepository: repository,
+		ID:                   id,
+		Color:                false,
+		TimeConsumedMS:       0,
+		LastClockTime:        time.Time{},
+		paused:               true,
 	}
 }
 

--- a/backend/server/domain/valid_moves.go
+++ b/backend/server/domain/valid_moves.go
@@ -196,14 +196,12 @@ func (g *Game) getKingCastlePositions(pos *Position, p IPiece, positions *[]*Pos
 // TODO: not the most efficient way to do this (implement it with a copy of the board)
 func (g *Game) filterMovesIfCheck(from *Position, positions []*Position) []*Position {
 	filteredPositions := []*Position{}
-	// fmt.Println("From: ", from, " To: ", positions)
 	for _, pos := range positions {
 		move := &Move{From: from, To: pos}
 		if !g.isCheckAfterMove(move) {
 			filteredPositions = append(filteredPositions, pos)
 		}
 	}
-	// fmt.Println(filteredPositions)
 	return filteredPositions
 }
 
@@ -222,6 +220,6 @@ func (g *Game) isCheckAfterMove(move *Move) bool {
 	if kingPos == nil {
 		fmt.Println("King not found: " + gameCopy.ColorToMove.String())
 	}
-	// fmt.Println("King pos: " + kingPos.String())
+
 	return gameCopy.Board.PositionIsUnderAttack(kingPos, enemyColor)
 }

--- a/backend/server/infrastructure/abandon_ws_controller.go
+++ b/backend/server/infrastructure/abandon_ws_controller.go
@@ -17,5 +17,5 @@ func NewAbandonWsController() *AbandonWsController {
 
 func (c *AbandonWsController) Invoke(ctx *wsrouter.Context) error {
 	output := c.uc.Invoke()
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return ctx.Enemy.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/abandon_ws_controller.go
+++ b/backend/server/infrastructure/abandon_ws_controller.go
@@ -16,5 +16,6 @@ func NewAbandonWsController() *AbandonWsController {
 }
 
 func (c *AbandonWsController) Invoke(ctx *wsrouter.Context) error {
-	return c.uc.Invoke(ctx)
+	output := c.uc.Invoke()
+	return ctx.EnemyRepository.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/backend_connection_repository.go
+++ b/backend/server/infrastructure/backend_connection_repository.go
@@ -23,6 +23,7 @@ func (r *BackendConnectionRepository) SendWebSocketMessage(msg interface{}) erro
 	return nil
 }
 
-func (r *BackendConnectionRepository) GetWebSocketConnection() *shared.WsConn {
-	return r.ws
+func (r *BackendConnectionRepository) ReadMessage() ([]byte, error) {
+	_, msg, err := r.ws.ReadMessage()
+	return msg, err
 }

--- a/backend/server/infrastructure/create_room_ws_controller.go
+++ b/backend/server/infrastructure/create_room_ws_controller.go
@@ -5,7 +5,6 @@ import (
 	"chess/server/domain"
 	"chess/server/shared/chesserror"
 	"encoding/json"
-	"log"
 )
 
 type CreateRoomWsController struct {
@@ -22,8 +21,8 @@ func (c *CreateRoomWsController) Invoke(body []byte) (*domain.Room, error) {
 	var p application.CreateRoomParams
 	err := json.Unmarshal(body, &p)
 	if err != nil {
-		log.Println("Error unmarshalling request create room:", err)
-		return nil, err
+		return nil, chesserror.NewError(chesserror.GenericError,
+			"Error unmarshalling input parameters.").WithCause(err)
 	}
 
 	room, err := c.uc.Invoke(&p)

--- a/backend/server/infrastructure/get_timers_ws_controller.go
+++ b/backend/server/infrastructure/get_timers_ws_controller.go
@@ -16,5 +16,6 @@ func NewGetTimersWsController() *GetTimersWsController {
 }
 
 func (c *GetTimersWsController) Invoke(ctx *wsrouter.Context) error {
-	return c.uc.Invoke(ctx)
+	output := c.uc.Invoke(ctx)
+	return ctx.OwnRepository.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/get_timers_ws_controller.go
+++ b/backend/server/infrastructure/get_timers_ws_controller.go
@@ -17,5 +17,5 @@ func NewGetTimersWsController() *GetTimersWsController {
 
 func (c *GetTimersWsController) Invoke(ctx *wsrouter.Context) error {
 	output := c.uc.Invoke(ctx)
-	return ctx.OwnRepository.SendWebSocketMessage(output)
+	return ctx.Player.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/get_valid_moves_ws_controller.go
+++ b/backend/server/infrastructure/get_valid_moves_ws_controller.go
@@ -3,8 +3,6 @@ package infrastructure
 import (
 	"chess/server/application"
 	"chess/server/shared/wsrouter"
-	"encoding/json"
-	"log"
 )
 
 type GetValidMovesWsController struct {
@@ -19,9 +17,8 @@ func NewGetValidMovesWsController() *GetValidMovesWsController {
 
 func (c *GetValidMovesWsController) Invoke(ctx *wsrouter.Context) error {
 	var p application.GetValidMovesParams
-	err := json.Unmarshal(ctx.Body, &p)
+	err := ctx.Bind(&p)
 	if err != nil {
-		log.Println("Error unmarshalling request create room:", err)
 		return err
 	}
 

--- a/backend/server/infrastructure/get_valid_moves_ws_controller.go
+++ b/backend/server/infrastructure/get_valid_moves_ws_controller.go
@@ -27,5 +27,5 @@ func (c *GetValidMovesWsController) Invoke(ctx *wsrouter.Context) error {
 		return err
 	}
 
-	return ctx.OwnRepository.SendWebSocketMessage(output)
+	return ctx.Player.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/move_piece_ws_controller.go
+++ b/backend/server/infrastructure/move_piece_ws_controller.go
@@ -3,8 +3,6 @@ package infrastructure
 import (
 	"chess/server/application"
 	"chess/server/shared/wsrouter"
-	"encoding/json"
-	"log"
 )
 
 type MovePieceWsController struct {
@@ -19,9 +17,8 @@ func NewMovePieceWsController() *MovePieceWsController {
 
 func (c *MovePieceWsController) Invoke(ctx *wsrouter.Context) error {
 	var p application.MovePieceParams
-	err := json.Unmarshal(ctx.Body, &p)
+	err := ctx.Bind(&p)
 	if err != nil {
-		log.Println("Error unmarshalling move piece params:", err)
 		return err
 	}
 

--- a/backend/server/infrastructure/move_piece_ws_controller.go
+++ b/backend/server/infrastructure/move_piece_ws_controller.go
@@ -27,9 +27,9 @@ func (c *MovePieceWsController) Invoke(ctx *wsrouter.Context) error {
 		return nil
 	}
 
-	if err := ctx.OwnRepository.SendWebSocketMessage(output); err != nil {
+	if err := ctx.Player.SendWebSocketMessage(output); err != nil {
 		return err
 	}
 
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return ctx.Enemy.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/request_draw_ws_controller.go
+++ b/backend/server/infrastructure/request_draw_ws_controller.go
@@ -17,5 +17,5 @@ func NewRequestDrawWsController() *RequestDrawWsController {
 
 func (c *RequestDrawWsController) Invoke(ctx *wsrouter.Context) error {
 	output := c.uc.Invoke(ctx)
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return ctx.Enemy.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/request_draw_ws_controller.go
+++ b/backend/server/infrastructure/request_draw_ws_controller.go
@@ -16,5 +16,6 @@ func NewRequestDrawWsController() *RequestDrawWsController {
 }
 
 func (c *RequestDrawWsController) Invoke(ctx *wsrouter.Context) error {
-	return c.uc.Invoke(ctx)
+	output := c.uc.Invoke(ctx)
+	return ctx.EnemyRepository.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/response_draw_ws_controller.go
+++ b/backend/server/infrastructure/response_draw_ws_controller.go
@@ -3,8 +3,6 @@ package infrastructure
 import (
 	"chess/server/application"
 	"chess/server/shared/wsrouter"
-	"encoding/json"
-	"log"
 )
 
 type ResponseDrawWsController struct {
@@ -19,9 +17,8 @@ func NewResponseDrawWsController() *ResponseDrawWsController {
 
 func (c *ResponseDrawWsController) Invoke(ctx *wsrouter.Context) error {
 	var p application.ResponseDrawParam
-	err := json.Unmarshal(ctx.Body, &p)
+	err := ctx.Bind(&p)
 	if err != nil {
-		log.Println("Error unmarshalling draw response:", err)
 		return err
 	}
 

--- a/backend/server/infrastructure/response_draw_ws_controller.go
+++ b/backend/server/infrastructure/response_draw_ws_controller.go
@@ -25,5 +25,6 @@ func (c *ResponseDrawWsController) Invoke(ctx *wsrouter.Context) error {
 		return err
 	}
 
-	return c.uc.Invoke(ctx, &p)
+	output := c.uc.Invoke(ctx, &p)
+	return ctx.EnemyRepository.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/response_draw_ws_controller.go
+++ b/backend/server/infrastructure/response_draw_ws_controller.go
@@ -23,5 +23,5 @@ func (c *ResponseDrawWsController) Invoke(ctx *wsrouter.Context) error {
 	}
 
 	output := c.uc.Invoke(ctx, &p)
-	return ctx.EnemyRepository.SendWebSocketMessage(output)
+	return ctx.Enemy.SendWebSocketMessage(output)
 }

--- a/backend/server/infrastructure/start_game_action_ws_controller.go
+++ b/backend/server/infrastructure/start_game_action_ws_controller.go
@@ -1,0 +1,17 @@
+package infrastructure
+
+import (
+	"chess/server/application"
+	"chess/server/shared/wsrouter"
+)
+
+func StartGameActionWsController(ctx *wsrouter.Context, durationMs int) error {
+	outputPlayer1, outputPlayer2 := application.StartGameAction(ctx.Player, ctx.Enemy, durationMs)
+
+	err := ctx.OwnRepository.SendWebSocketMessage(outputPlayer1)
+	if err != nil {
+		return err
+	}
+
+	return ctx.EnemyRepository.SendWebSocketMessage(outputPlayer2)
+}

--- a/backend/server/infrastructure/start_game_action_ws_controller.go
+++ b/backend/server/infrastructure/start_game_action_ws_controller.go
@@ -8,10 +8,10 @@ import (
 func StartGameActionWsController(ctx *wsrouter.Context, durationMs int) error {
 	outputPlayer1, outputPlayer2 := application.StartGameAction(ctx.Player, ctx.Enemy, durationMs)
 
-	err := ctx.OwnRepository.SendWebSocketMessage(outputPlayer1)
+	err := ctx.Player.SendWebSocketMessage(outputPlayer1)
 	if err != nil {
 		return err
 	}
 
-	return ctx.EnemyRepository.SendWebSocketMessage(outputPlayer2)
+	return ctx.Enemy.SendWebSocketMessage(outputPlayer2)
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"chess/server/application"
 	"chess/server/domain"
 	"chess/server/infrastructure"
 	"chess/server/shared"
@@ -177,7 +176,8 @@ func (s *Server) handleGame(room *domain.Room, c domain.ConnectionRepository, is
 
 	cEnemy := infrastructure.NewBackendConnectionRepository(enemy.Ws)
 	if isHost {
-		err := application.StartGameAction(player, enemy, c, cEnemy, 10*60*1000)
+		ctx := wsrouter.NewContext(room.Game, player, enemy, c, cEnemy, nil)
+		err := infrastructure.StartGameActionWsController(ctx, 10*60*1000)
 		if err != nil {
 			log.Println("Error starting game: ", err)
 			_ = c.SendWebSocketMessage(err)

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -138,7 +138,7 @@ func (s *Server) initWebsocket() {
 				return
 			}
 
-			s.handleGame(room, c, true, wg)
+			s.handleGame(room, true, wg)
 
 		case "join-room":
 			log.Println("Request join room")
@@ -150,14 +150,14 @@ func (s *Server) initWebsocket() {
 				return
 			}
 
-			s.handleGame(room, c, false, wg)
+			s.handleGame(room, false, wg)
 		}
 
 		wg.Wait()
 	}))
 }
 
-func (s *Server) handleGame(room *domain.Room, c domain.ConnectionRepository, isHost bool, wg *sync.WaitGroup) {
+func (s *Server) handleGame(room *domain.Room, isHost bool, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	log.Println("Room activated")
@@ -174,14 +174,13 @@ func (s *Server) handleGame(room *domain.Room, c domain.ConnectionRepository, is
 		}
 	}
 
-	cEnemy := infrastructure.NewBackendConnectionRepository(enemy.Ws)
 	if isHost {
-		ctx := wsrouter.NewContext(room.Game, player, enemy, c, cEnemy, nil)
+		ctx := wsrouter.NewContext(room.Game, player, enemy, nil)
 		err := infrastructure.StartGameActionWsController(ctx, 10*60*1000)
 		if err != nil {
 			log.Println("Error starting game: ", err)
-			_ = c.SendWebSocketMessage(err)
-			_ = cEnemy.SendWebSocketMessage(err)
+			_ = player.SendWebSocketMessage(err)
+			_ = enemy.SendWebSocketMessage(err)
 			s.roomManager.RemoveRoom(room.ID)
 			return
 		}
@@ -196,12 +195,12 @@ func (s *Server) handleGame(room *domain.Room, c domain.ConnectionRepository, is
 
 	for {
 		// Blocking when waiting for the enemy player action
-		_, message, err := player.Ws.ReadMessage()
+		message, err := player.ReadMessage()
 		if err != nil {
 			log.Println("Some error:", err)
 			if room.GetRoomSize() > 1 {
 				log.Println("Trying to send abandon message to enemy")
-				ctx := wsrouter.NewContext(room.Game, player, enemy, c, cEnemy, nil)
+				ctx := wsrouter.NewContext(room.Game, player, enemy, nil)
 				s.wsRouter.Handle("abandon", ctx)
 
 				_ = room.RemovePlayer(player)
@@ -213,7 +212,7 @@ func (s *Server) handleGame(room *domain.Room, c domain.ConnectionRepository, is
 		reqAction, _ := jsonparser.GetString(message, "action")
 		reqBody, _, _, _ := jsonparser.Get(message, "body")
 
-		ctx := wsrouter.NewContext(room.Game, player, enemy, c, cEnemy, reqBody)
+		ctx := wsrouter.NewContext(room.Game, player, enemy, reqBody)
 		s.wsRouter.Handle(reqAction, ctx)
 	}
 }

--- a/backend/server/shared/wsrouter/chess_context.go
+++ b/backend/server/shared/wsrouter/chess_context.go
@@ -2,6 +2,7 @@ package wsrouter
 
 import (
 	"chess/server/domain"
+	"chess/server/shared/chesserror"
 	"encoding/json"
 )
 
@@ -32,4 +33,14 @@ func NewContext(game *domain.Game, player, enemy *domain.Player,
 func (c *Context) String() string {
 	b, _ := json.Marshal(c)
 	return string(b)
+}
+
+func (c *Context) Bind(dst interface{}) error {
+	err := json.Unmarshal(c.Body, dst)
+	if err != nil {
+		return chesserror.NewError(chesserror.GenericError,
+			"Error unmarshalling input parameters.").WithCause(err)
+	}
+
+	return nil
 }

--- a/backend/server/shared/wsrouter/chess_context.go
+++ b/backend/server/shared/wsrouter/chess_context.go
@@ -9,24 +9,19 @@ import (
 type RequestBody []byte
 
 type Context struct {
-	Game            *domain.Game
-	Player          *domain.Player
-	Enemy           *domain.Player
-	OwnRepository   domain.ConnectionRepository
-	EnemyRepository domain.ConnectionRepository
+	Game   *domain.Game
+	Player *domain.Player
+	Enemy  *domain.Player
 
 	Body RequestBody
 }
 
-func NewContext(game *domain.Game, player, enemy *domain.Player,
-	ownRep, enemyRep domain.ConnectionRepository, body RequestBody) *Context {
+func NewContext(game *domain.Game, player, enemy *domain.Player, body RequestBody) *Context {
 	return &Context{
-		Game:            game,
-		Player:          player,
-		Enemy:           enemy,
-		OwnRepository:   ownRep,
-		EnemyRepository: enemyRep,
-		Body:            body,
+		Game:   game,
+		Player: player,
+		Enemy:  enemy,
+		Body:   body,
 	}
 }
 

--- a/backend/server/shared/wsrouter/wsrouter.go
+++ b/backend/server/shared/wsrouter/wsrouter.go
@@ -38,5 +38,6 @@ func (r *WsRouter) Handle(path string, ctx *Context) {
 	err := handler(ctx)
 	if err != nil {
 		log.Printf("=> Error running handler for path %q: %v", path, err)
+		_ = ctx.OwnRepository.SendWebSocketMessage(err)
 	}
 }

--- a/backend/server/shared/wsrouter/wsrouter.go
+++ b/backend/server/shared/wsrouter/wsrouter.go
@@ -38,6 +38,6 @@ func (r *WsRouter) Handle(path string, ctx *Context) {
 	err := handler(ctx)
 	if err != nil {
 		log.Printf("=> Error running handler for path %q: %v", path, err)
-		_ = ctx.OwnRepository.SendWebSocketMessage(err)
+		_ = ctx.Player.SendWebSocketMessage(err)
 	}
 }


### PR DESCRIPTION
- Moved repository calls from use cases to controllers in most actions (missing create/join room actions).
- Added ```wsrouter.Context.Bind(...)``` method so controllers can use it to unmarshall input parameters. This way a wrapper can be added to the error.
- Changed ```*shared.WsConn``` to be ```domain.ConnectionRepository``` in ```domain.Player```. Removed ```ConnectionRepository``` attributes in ```wsrouter.Context```.

